### PR TITLE
Fix droplet reconclier issue

### DIFF
--- a/apis/compute/v1alpha1/droplet_types.go
+++ b/apis/compute/v1alpha1/droplet_types.go
@@ -54,32 +54,32 @@ type DropletParameters struct {
 	// that you wish to embed in the Droplet's root account upon creation.
 	// +optional
 	// +immutable
-	SSHKeys []string `json:"ssh_keys"`
+	SSHKeys []string `json:"ssh_keys,omitempty"`
 
 	// Backups: A boolean indicating whether automated backups should be enabled
 	// for the Droplet. Automated backups can only be enabled when the Droplet is
 	// created.
 	// +optional
 	// +immutable
-	Backups *bool `json:"backups"`
+	Backups *bool `json:"backups,omitempty"`
 
 	// IPv6: A boolean indicating whether IPv6 is enabled on the Droplet.
 	// +optional
 	// +immutable
-	IPv6 *bool `json:"ipv6"`
+	IPv6 *bool `json:"ipv6,omitempty"`
 
 	// PrivateNetworking: This parameter has been deprecated. Use 'vpc_uuid'
 	// instead to specify a VPC network for the Droplet. If no `vpc_uuid` is
 	// provided, the Droplet will be placed in the default VPC.
 	// +optional
 	// +immutable
-	PrivateNetworking *bool `json:"private_networking"`
+	PrivateNetworking *bool `json:"private_networking,omitempty"`
 
 	// Monitoring: A boolean indicating whether to install the DigitalOcean
 	// agent for monitoring.
 	// +optional
 	// +immutable
-	Monitoring *bool `json:"monitoring"`
+	Monitoring *bool `json:"monitoring,omitempty"`
 
 	// Volumes: A flat array including the unique string identifier for each block
 	// storage volume to be attached to the Droplet. At the moment a volume can only
@@ -92,7 +92,7 @@ type DropletParameters struct {
 	// is created. Tag names can either be existing or new tags.
 	// +optional
 	// +immutable
-	Tags []string `json:"tags"`
+	Tags []string `json:"tags,omitempty"`
 
 	// VPCUUID: A string specifying the UUID of the VPC to which the Droplet
 	// will be assigned. If excluded, beginning on April 7th, 2020, the Droplet

--- a/pkg/clients/compute/droplet.go
+++ b/pkg/clients/compute/droplet.go
@@ -82,3 +82,16 @@ func LateInitializeSpec(p *v1alpha1.DropletParameters, observed godo.Droplet) {
 	p.Tags = do.LateInitializeStringSlice(p.Tags, observed.Tags)
 	p.VPCUUID = do.LateInitializeString(p.VPCUUID, observed.VPCUUID)
 }
+
+// IsErrorNotFound checks for response of DigitalOcean GET API call
+// to identify if the result is '404 not found' error or something
+// else.
+func IsErrorNotFound(err error, response *godo.Response) error {
+	if err.Error() == "dropletID is invalid because cannot be less than 1" {
+		return nil
+	}
+	if response != nil && response.StatusCode == 404 {
+		return nil
+	}
+	return err
+}

--- a/pkg/clients/compute/droplet.go
+++ b/pkg/clients/compute/droplet.go
@@ -83,10 +83,10 @@ func LateInitializeSpec(p *v1alpha1.DropletParameters, observed godo.Droplet) {
 	p.VPCUUID = do.LateInitializeString(p.VPCUUID, observed.VPCUUID)
 }
 
-// IsErrorNotFound checks for response of DigitalOcean GET API call
-// to identify if the result is '404 not found' error or something
-// else.
-func IsErrorNotFound(err error, response *godo.Response) error {
+// IgnoreNotFound checks for response of DigitalOcean GET API call
+// and the content of returned error to ignore it if the response
+// is a '404 not found' error otherwise bubble up the error.
+func IgnoreNotFound(err error, response *godo.Response) error {
 	if err.Error() == "dropletID is invalid because cannot be less than 1" {
 		return nil
 	}

--- a/pkg/controller/compute/droplet.go
+++ b/pkg/controller/compute/droplet.go
@@ -137,6 +137,11 @@ func (c *dropletExternal) Create(ctx context.Context, mg resource.Managed) (mana
 		cr.Status.AtProvider.ID = droplet.ID
 		cr.Status.AtProvider.CreationTimestamp = droplet.Created
 		cr.Status.AtProvider.Status = droplet.Status
+
+		// TODO(khos2ow): when we go from here back to Observe() `AtProvider.ID`
+		// is still empty which causes the observer to send a create request to
+		// DigitalOcean API once more! This may help :cross-finger:
+		time.Sleep(1 * time.Second)
 	}
 	return managed.ExternalCreation{}, errors.Wrap(err, errDropletCreateFailed)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR fixes droplet reconciling loop issues, i.e. adding missing `omitempty` json tag to optional parameters. But the most notable change is adding a 1 second sleep in after `Create` was done in the following scenario:

1. create a `Droplet`
2. `Observe()` starts and sees the resource doesn't exist
3. `Create()` starts and eventually sets `Status.AtProvider.ID`
4. process return to `Observe()` but `Status.AtProvider.ID` is still empty and retriggers API to create droplet _again_

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
